### PR TITLE
Split scrum report functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Create your configuration file:
         "@lbourdages",
         "@pastjean"
       ],
+      "split_report": true,
       "question_sets": [
         {
           "questions": [
@@ -48,6 +49,8 @@ Create your configuration file:
   ]
 }
 ```
+
+`split_report` whether to post each scrum entry as a separate messages or post all post all scrum entries in the same message.
 
 Run the bot with a slack bot user token
 

--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,7 @@
         "pa",
         "jo"
       ],
+      "split_report": true,
       "question_sets": [
         {
           "questions": [

--- a/scrum/config.go
+++ b/scrum/config.go
@@ -10,6 +10,35 @@ import (
 	"github.com/robfig/cron"
 )
 
+// {
+//   "timezone": "America/Montreal",
+//   "teams": [
+//     {
+//       "channel": "general",
+//       "name": "L337",
+//       "members": [
+//         "fboutin2",
+//         "lbourdages",
+//         "pa",
+//         "jo"
+//       ],
+//       "split_report": false,
+//       "question_sets": [
+//         {
+//           "questions": [
+//             "What did you do yesterday?",
+//             "What will you do today?",
+//             "Are you being blocked by someone for a review? who ? why ?",
+//             "How will you dominate the world"
+//           ],
+//           "report_schedule_cron": "@every 30s",
+//           "first_reminder_limit": "-8s",
+//           "last_reminder_limit": "-3s"
+//         }
+//       ]
+//     }
+//   ]
+// }
 type (
 	ConfigurationProvider interface {
 		Config() *Config
@@ -22,27 +51,13 @@ type (
 		Teams    []TeamConfig `json:"teams"`
 	}
 
-	// TeamConfig is the file format for the configuration of a team in json
-	//	{
-	//	"channel": "analyticsinternal",
-	//	"name": "Usage Analytics",
-	//	"members": ["@jrochette", "@pastjean", "@lbourdages", "@gbergeron", "@mlachapelle", "@aemond", "@gprovost"],
-	//	"question_sets": [{
-	//	  "questions":  [
-	//	    "What did you do yesterday? _(jira if needed)_",
-	//	    "What will you do today?",
-	//	    "Are you being blocked by someone for a review? who ? why ?"
-	//	  ],
-	//	"report_schedule_cron": "0 0 8 * * MON",
-	//	"first_reminder_limit": "+55m",
-	//	"last_reminder_limit": "+65m"
-	//	}
 	TeamConfig struct {
 		Name         string              `json:"name"`
 		Channel      string              `json:"channel"`
 		Members      []string            `json:"members"`
 		QuestionSets []QuestionSetConfig `json:"question_sets"`
 		Timezone     string              `json:"timezone"`
+		SplitReport  bool                `json:"split_report"`
 	}
 
 	QuestionSetConfig struct {
@@ -137,6 +152,7 @@ func (tc *TeamConfig) ToTeam() *Team {
 		Channel:       tc.Channel,
 		Members:       tc.Members,
 		QuestionsSets: qsets,
+		SplitReport:   tc.SplitReport,
 	}
 
 	if tc.Timezone != "" {

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -114,12 +114,22 @@ func (ts *TeamState) sendReportForTeam(qs *QuestionSet) {
 
 	}
 
-	params := slack.PostMessageParameters{
-		AsUser:      true,
-		Attachments: attachments,
+	if ts.SplitReport {
+		ts.service.slackBotAPI.PostMessage(ts.Channel, ":parrotcop: Alrighty! Here's the scrum report for today!", slack.PostMessageParameters{AsUser: true})
+		for i := 0; i < len(attachments); i++ {
+			params := slack.PostMessageParameters{
+				AsUser:      true,
+				Attachments: []slack.Attachment{attachments[i]},
+			}
+			ts.service.slackBotAPI.PostMessage(ts.Channel, "*Scrum by*", params)
+		}
+	} else {
+		params := slack.PostMessageParameters{
+			AsUser:      true,
+			Attachments: attachments,
+		}
+		ts.service.slackBotAPI.PostMessage(ts.Channel, ":parrotcop: Alrighty! Here's the scrum report for today!", params)
 	}
-
-	ts.service.slackBotAPI.PostMessage(ts.Channel, ":parrotcop: Alrighty! Here's the scrum report for today!", params)
 
 	if len(didNotDoReport) > 0 {
 		ts.service.slackBotAPI.PostMessage(ts.Channel, fmt.Sprintln("And lastly we should take a little time to shame", didNotDoReport), SlackParams)

--- a/scrum/state.go
+++ b/scrum/state.go
@@ -14,6 +14,7 @@ type (
 		QuestionsSets []*QuestionSet
 		Timezone      *time.Location
 		OutOfOffice   []string
+		SplitReport   bool
 	}
 
 	QuestionSet struct {


### PR DESCRIPTION
Add a param in the configuration (team based) to post the scrum report with one message per scrum entry, allowing slack threads and reactions on each entry, as opposed to the scrum report in a single message.